### PR TITLE
[Feat-Fix] 등급별 동/구 필터 API 개발 및 평균 등급 산출 로직 추가

### DIFF
--- a/districts/urls.py
+++ b/districts/urls.py
@@ -1,0 +1,9 @@
+from rest_framework.routers import SimpleRouter
+from .views import *
+
+app_name = "districts"
+
+router = SimpleRouter(trailing_slash=False)
+router.register("", DistrictViewSet, basename="districts")
+
+urlpatterns = router.urls

--- a/districts/views.py
+++ b/districts/views.py
@@ -1,3 +1,217 @@
-from django.shortcuts import render
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from django.utils.timezone import now
+from .models import *
+from django.db.models import Max, Count
 
-# Create your views here.
+class DistrictViewSet(viewsets.ViewSet):
+
+    @action(detail=False, methods=["get"], url_path="gu/metrics")
+    def gu_metrics(self, request):
+
+        latest_date = DistrictMetric.objects.aggregate(latest=Max("as_of_date"))["latest"]
+        qs = DistrictMetric.objects.filter(as_of_date=latest_date) \
+            .select_related("district")
+
+        data = [
+            {
+                "gu_code": d.district.id,
+                "sido": d.district.sido,
+                "sigungu": d.district.sigungu,
+                "center_lat": float(d.district.center_lat),
+                "center_lng": float(d.district.center_lng),
+                "total_grade": d.total_grade
+            }
+            for d in qs
+        ]
+        return Response({
+            "status": "success",
+            "message": "구 집계 조회 성공",
+            "code": 200,
+            "data": {
+                "items": data,
+                "as_of_date": latest_date,
+                "count": len(data)
+            }
+        })
+
+    @action(detail=False, methods=["get"], url_path="search")
+    def search_districts(self, request):
+        q = request.GET.get("q", "")
+        qs = District.objects.filter(dong__icontains=q)[:20]
+        data = [
+            {
+                "id": d.id,
+                "sido": d.sido,
+                "sigungu": d.sigungu,
+                "dong": d.dong,
+                "center_lat": float(d.center_lat),
+                "center_lng": float(d.center_lng)
+            }
+            for d in qs
+        ]
+        return Response({
+            "status": "success",
+            "message": "동 검색 성공",
+            "code": 200,
+            "data": {
+                "items": data,
+                "count": len(data)
+            }
+        })
+
+    @action(detail=True, methods=["get"], url_path="metrics")
+    def district_metrics(self, request, pk=None):
+        latest = DistrictMetric.objects.filter(district_id=pk) \
+                                        .order_by("-as_of_date") \
+                                        .first()
+        if not latest:
+            return Response({
+                "status": "error",
+                "message": "지표를 찾을 수 없습니다",
+                "code": 404,
+                "data": { "detail": f"district_id={pk}" }
+            }, status=404)
+
+        return Response({
+            "status": "success",
+            "message": "동 지표 조회 성공",
+            "code": 200,
+            "data": {
+                "district_id": latest.district_id,
+                "as_of_date": latest.as_of_date,
+                "total_grade": latest.total_grade,
+                "ground_stability": latest.ground_stability,
+                "groundwater_impact": latest.groundwater_impact,
+                "underground_density": latest.underground_density,
+                "old_building_dist": latest.old_building_dist,
+                "analysis_text": latest.analysis_text
+            }
+        })
+
+    @action(detail=False, methods=["get"], url_path="risk/by-coord")
+    def risk_by_coord(self, request):
+        try:
+            lat = float(request.GET.get("lat"))
+            lng = float(request.GET.get("lng"))
+        except (TypeError, ValueError):
+            return Response({
+                "status": "error",
+                "message": "필수 파라미터 누락",
+                "code": 400,
+                "data": { "detail": "lat,lng required" }
+            }, status=400)
+
+        from math import radians, sin, cos, acos
+        def distance(lat1, lng1, lat2, lng2):
+            R = 6371000
+            lat1, lng1, lat2, lng2 = map(radians, [lat1, lng1, lat2, lng2])
+            return R * acos(
+                cos(lat1) * cos(lat2) * cos(lng2 - lng1) + sin(lat1) * sin(lat2)
+            )
+
+        districts = District.objects.all()
+        nearest = min(districts, key=lambda d: distance(lat, lng, float(d.center_lat), float(d.center_lng)))
+
+        latest_metric = DistrictMetric.objects.filter(district=nearest) \
+                                                .order_by("-as_of_date") \
+                                                .first()
+
+        danger = latest_metric.total_grade in ["G4", "G5"]
+
+        return Response({
+            "status": "success",
+            "message": "좌표 위험 요약 조회 성공",
+            "code": 200,
+            "data": {
+                "district": {
+                    "id": nearest.id,
+                    "sido": nearest.sido,
+                    "sigungu": nearest.sigungu,
+                    "dong": nearest.dong
+                },
+                "total_grade": latest_metric.total_grade,
+                "danger": danger,
+                "as_of_date": latest_metric.as_of_date
+            }
+        })
+
+    @action(detail=False, methods=["post"], url_path="gu/metrics/by-grade")
+    def gu_metrics_by_grade(self, request):
+        grade = request.data.get("grade")
+        match_rule = request.data.get("match_rule", "any")
+        if grade not in ["G1","G2","G3","G4","G5"]:
+            return Response({
+                "status": "error",
+                "message": "잘못된 등급",
+                "code": 400,
+                "data": { "detail": "grade must be one of G1..G5" }
+            }, status=400)
+
+        latest_date = DistrictMetric.objects.aggregate(latest=Max("as_of_date"))["latest"]
+
+        grouped = DistrictMetric.objects.filter(as_of_date=latest_date) \
+                                        .values("district__sigungu") \
+                                        .annotate(matching_count=Count("id"))
+
+        data = [
+            {
+                "gu_code": g["district__sigungu"], #임시
+                "sido": "서울특별시",
+                "sigungu": g["district__sigungu"],
+                "center_lat": 0,
+                "center_lng": 0,
+                "matching_district_count": g["matching_count"]
+            }
+            for g in grouped
+        ]
+        return Response({
+            "status": "success",
+            "message": "구 등급 필터 조회 성공",
+            "code": 200,
+            "data": {
+                "items": data,
+                "as_of_date": latest_date,
+                "count": len(data)
+            }
+        })
+
+    @action(detail=False, methods=["post"], url_path="by-grade")
+    def districts_by_grade(self, request):
+        grade = request.data.get("grade")
+        if grade not in ["G1","G2","G3","G4","G5"]:
+            return Response({
+                "status": "error",
+                "message": "잘못된 등급",
+                "code": 400,
+                "data": { "detail": "grade must be one of G1..G5" }
+            }, status=400)
+
+        latest_date = DistrictMetric.objects.aggregate(latest=Max("as_of_date"))["latest"]
+
+        qs = DistrictMetric.objects.filter(as_of_date=latest_date, total_grade=grade) \
+                                    .select_related("district")
+
+        data = [
+            {
+                "id": d.district.id,
+                "sido": d.district.sido,
+                "sigungu": d.district.sigungu,
+                "dong": d.district.dong,
+                "center_lat": float(d.district.center_lat),
+                "center_lng": float(d.district.center_lng)
+            }
+            for d in qs
+        ]
+
+        return Response({
+            "status": "success",
+            "message": "동 등급 필터 조회 성공",
+            "code": 200,
+            "data": {
+                "items": data,
+                "as_of_date": latest_date,
+                "count": len(data)
+            }
+        })

--- a/districts/views.py
+++ b/districts/views.py
@@ -1,45 +1,54 @@
+import csv
+import os
+from collections import defaultdict
+from django.conf import settings
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from django.utils.timezone import now
-from .models import *
-from django.db.models import Max, Count
+from rest_framework import status
+from .models import District, DistrictMetric
+from django.db.models import Max
+
+
+# 등급 임시 매핑용
+grade_map = {
+    11110515: "G4", # 청운효자동
+    11110530: "G2", # 사직동
+    # ...
+}
+
 
 class DistrictViewSet(viewsets.ViewSet):
 
     @action(detail=False, methods=["get"], url_path="gu/metrics")
     def gu_metrics(self, request):
-
         latest_date = DistrictMetric.objects.aggregate(latest=Max("as_of_date"))["latest"]
-        qs = DistrictMetric.objects.filter(as_of_date=latest_date) \
-            .select_related("district")
+        qs = DistrictMetric.objects.filter(as_of_date=latest_date).select_related("district")
 
         data = [
             {
-                "gu_code": d.district.id,
+                "gu_code": int(str(d.district.id)[:5]),  # 동코드 앞 5자리 → 구코드로 변환 시킴
                 "sido": d.district.sido,
                 "sigungu": d.district.sigungu,
                 "center_lat": float(d.district.center_lat),
                 "center_lng": float(d.district.center_lng),
-                "total_grade": d.total_grade
+                "total_grade": d.total_grade,
             }
             for d in qs
         ]
+
         return Response({
             "status": "success",
             "message": "구 집계 조회 성공",
             "code": 200,
-            "data": {
-                "items": data,
-                "as_of_date": latest_date,
-                "count": len(data)
-            }
+            "data": {"items": data, "as_of_date": latest_date, "count": len(data)}
         })
 
     @action(detail=False, methods=["get"], url_path="search")
     def search_districts(self, request):
         q = request.GET.get("q", "")
         qs = District.objects.filter(dong__icontains=q)[:20]
+
         data = [
             {
                 "id": d.id,
@@ -47,31 +56,27 @@ class DistrictViewSet(viewsets.ViewSet):
                 "sigungu": d.sigungu,
                 "dong": d.dong,
                 "center_lat": float(d.center_lat),
-                "center_lng": float(d.center_lng)
+                "center_lng": float(d.center_lng),
             }
             for d in qs
         ]
+
         return Response({
             "status": "success",
             "message": "동 검색 성공",
             "code": 200,
-            "data": {
-                "items": data,
-                "count": len(data)
-            }
+            "data": {"items": data, "count": len(data)}
         })
 
     @action(detail=True, methods=["get"], url_path="metrics")
     def district_metrics(self, request, pk=None):
-        latest = DistrictMetric.objects.filter(district_id=pk) \
-                                        .order_by("-as_of_date") \
-                                        .first()
+        latest = DistrictMetric.objects.filter(district_id=pk).order_by("-as_of_date").first()
         if not latest:
             return Response({
                 "status": "error",
                 "message": "지표를 찾을 수 없습니다",
                 "code": 404,
-                "data": { "detail": f"district_id={pk}" }
+                "data": {"detail": f"district_id={pk}"}
             }, status=404)
 
         return Response({
@@ -86,7 +91,7 @@ class DistrictViewSet(viewsets.ViewSet):
                 "groundwater_impact": latest.groundwater_impact,
                 "underground_density": latest.underground_density,
                 "old_building_dist": latest.old_building_dist,
-                "analysis_text": latest.analysis_text
+                "analysis_text": latest.analysis_text,
             }
         })
 
@@ -100,24 +105,20 @@ class DistrictViewSet(viewsets.ViewSet):
                 "status": "error",
                 "message": "필수 파라미터 누락",
                 "code": 400,
-                "data": { "detail": "lat,lng required" }
+                "data": {"detail": "lat,lng required"}
             }, status=400)
 
-        from math import radians, sin, cos, acos
+        from math import radians, cos, sin, acos
+
         def distance(lat1, lng1, lat2, lng2):
             R = 6371000
             lat1, lng1, lat2, lng2 = map(radians, [lat1, lng1, lat2, lng2])
-            return R * acos(
-                cos(lat1) * cos(lat2) * cos(lng2 - lng1) + sin(lat1) * sin(lat2)
-            )
+            return R * acos(cos(lat1) * cos(lat2) * cos(lng2 - lng1) + sin(lat1) * sin(lat2))
 
         districts = District.objects.all()
         nearest = min(districts, key=lambda d: distance(lat, lng, float(d.center_lat), float(d.center_lng)))
 
-        latest_metric = DistrictMetric.objects.filter(district=nearest) \
-                                                .order_by("-as_of_date") \
-                                                .first()
-
+        latest_metric = DistrictMetric.objects.filter(district=nearest).order_by("-as_of_date").first()
         danger = latest_metric.total_grade in ["G4", "G5"]
 
         return Response({
@@ -129,89 +130,109 @@ class DistrictViewSet(viewsets.ViewSet):
                     "id": nearest.id,
                     "sido": nearest.sido,
                     "sigungu": nearest.sigungu,
-                    "dong": nearest.dong
+                    "dong": nearest.dong,
                 },
                 "total_grade": latest_metric.total_grade,
                 "danger": danger,
-                "as_of_date": latest_metric.as_of_date
+                "as_of_date": latest_metric.as_of_date,
             }
         })
 
-    @action(detail=False, methods=["post"], url_path="gu/metrics/by-grade")
+    @action(detail=False, methods=["get"], url_path="gu/metrics/by-grade")
     def gu_metrics_by_grade(self, request):
-        grade = request.data.get("grade")
-        match_rule = request.data.get("match_rule", "any")
-        if grade not in ["G1","G2","G3","G4","G5"]:
+        grade = request.GET.get("grade")
+        match_rule = request.GET.get("match_rule", "any")
+
+        if grade not in ["G1", "G2", "G3", "G4", "G5"]:
             return Response({
                 "status": "error",
                 "message": "잘못된 등급",
                 "code": 400,
-                "data": { "detail": "grade must be one of G1..G5" }
+                "data": {"detail": "grade must be one of G1..G5"}
             }, status=400)
 
-        latest_date = DistrictMetric.objects.aggregate(latest=Max("as_of_date"))["latest"]
+        csv_path = os.path.join(settings.BASE_DIR, "data", "서울시행정동.csv")
+        gu_data = defaultdict(list)
 
-        grouped = DistrictMetric.objects.filter(as_of_date=latest_date) \
-                                        .values("district__sigungu") \
-                                        .annotate(matching_count=Count("id"))
+        with open(csv_path, newline='', encoding="utf-8") as f:
+            reader = csv.reader(f)
+            next(reader)
+            for row in reader:
+                dong_code = int(row[0])
+                sido = row[1]
+                sigungu = row[2]
+                dong = row[3]
+                lng = float(row[4])
+                lat = float(row[5])
 
-        data = [
-            {
-                "gu_code": g["district__sigungu"], #임시
-                "sido": "서울특별시",
-                "sigungu": g["district__sigungu"],
-                "center_lat": 0,
-                "center_lng": 0,
-                "matching_district_count": g["matching_count"]
-            }
-            for g in grouped
-        ]
+                dong_grade = grade_map.get(dong_code)
+                if dong_grade:
+                    gu_code = int(str(dong_code)[:5])
+                    gu_data[(gu_code, sido, sigungu)].append((lat, lng, dong_grade))
+
+        results = []
+        for (gu_code, sido, sigungu), records in gu_data.items():
+            avg_lat = sum(r[0] for r in records) / len(records)
+            avg_lng = sum(r[1] for r in records) / len(records)
+            grade_nums = [int(r[2][1]) for r in records]  # G1 → 1, G5 → 5로 숫자 매칭함
+            avg_grade = sum(grade_nums) / len(grade_nums)
+            final_grade = f"G{round(avg_grade)}"
+
+            results.append({
+                "gu_code": gu_code,
+                "sido": sido,
+                "sigungu": sigungu,
+                "center_lat": round(avg_lat, 6),
+                "center_lng": round(avg_lng, 6),
+                "matching_district_count": len(records),
+                "final_grade": final_grade,
+            })
+
         return Response({
             "status": "success",
             "message": "구 등급 필터 조회 성공",
             "code": 200,
-            "data": {
-                "items": data,
-                "as_of_date": latest_date,
-                "count": len(data)
-            }
+            "data": {"items": results, "as_of_date": "2025-08-01", "count": len(results)}
         })
 
-    @action(detail=False, methods=["post"], url_path="by-grade")
+    @action(detail=False, methods=["get"], url_path="by-grade")
     def districts_by_grade(self, request):
-        grade = request.data.get("grade")
-        if grade not in ["G1","G2","G3","G4","G5"]:
+        grade = request.GET.get("grade")
+        if grade not in ["G1", "G2", "G3", "G4", "G5"]:
             return Response({
                 "status": "error",
                 "message": "잘못된 등급",
                 "code": 400,
-                "data": { "detail": "grade must be one of G1..G5" }
+                "data": {"detail": "grade must be one of G1..G5"}
             }, status=400)
 
-        latest_date = DistrictMetric.objects.aggregate(latest=Max("as_of_date"))["latest"]
+        csv_path = os.path.join(settings.BASE_DIR, "data", "서울시행정동.csv")
+        data = []
 
-        qs = DistrictMetric.objects.filter(as_of_date=latest_date, total_grade=grade) \
-                                    .select_related("district")
+        with open(csv_path, newline='', encoding="utf-8") as f:
+            reader = csv.reader(f)
+            next(reader)
+            for row in reader:
+                dong_code = int(row[0])
+                sido = row[1]
+                sigungu = row[2]
+                dong = row[3]
+                lng = float(row[4])
+                lat = float(row[5])
 
-        data = [
-            {
-                "id": d.district.id,
-                "sido": d.district.sido,
-                "sigungu": d.district.sigungu,
-                "dong": d.district.dong,
-                "center_lat": float(d.district.center_lat),
-                "center_lng": float(d.district.center_lng)
-            }
-            for d in qs
-        ]
+                if grade_map.get(dong_code) == grade:
+                    data.append({
+                        "id": dong_code,
+                        "sido": sido,
+                        "sigungu": sigungu,
+                        "dong": dong,
+                        "center_lat": lat,
+                        "center_lng": lng,
+                    })
 
         return Response({
             "status": "success",
             "message": "동 등급 필터 조회 성공",
             "code": 200,
-            "data": {
-                "items": data,
-                "as_of_date": latest_date,
-                "count": len(data)
-            }
+            "data": {"items": data, "as_of_date": "2025-08-01", "count": len(data)}
         })

--- a/project/urls.py
+++ b/project/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/incidents/', include('incidents.urls', namespace='incidents')),
     path('api/v1/places/', include('places.urls', namespace='places')),
+    path('api/v1/districts/', include('districts.urls', namespace='districts')),
 ]


### PR DESCRIPTION
## 🔍 What is the PR?

- /api/v1/districts/by-grade (동 단위 필터 API, GET 버전) 구현
- /api/v1/gu/metrics/by-grade (구 단위 필터 API, GET 버전) 구현
- 각 구의 소속 동들의 위험도(등급) 평균 → 반올림하여 최종 구 등급 산출
- dong_code → gu_code 변환 로직 반영 (dong_code 앞 5자리 사용)
- CSV(서울시행정동.csv) 기반 데이터 로딩 및 그룹핑 로직 추가
- 잘못된 grade 값 요청 시 400 응답 처리

## 📍 PR Point

- 구 평균 등급 산출: 구 단위 필터에서 소속 동들의 등급 평균값을 반올림하여 최종 등급으로 결정
- CSV 기반 필터링: DB 대신 CSV(서울시행정동.csv) 기반으로 동/구 단위 데이터를 조회)

## 📢 Notices

- grade_map은 현재 임시 하드코딩 상태 → 추후 DB 또는 CSV에 grade 컬럼 추가 시 대체 필요
- gu_code는 dong_code 앞 5자리를 기준으로 산출 (행정구역 코드 규칙 반영)

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
