### PR TITLE
feat-fix: 부동산 안심존 로직

### DIFF
--- a/districts/urls.py
+++ b/districts/urls.py
@@ -1,9 +1,11 @@
 from rest_framework.routers import SimpleRouter
-from .views import *
+from .views import DistrictViewSet, SafezoneViewSet
 
 app_name = "districts"
 
 router = SimpleRouter(trailing_slash=False)
+
 router.register("", DistrictViewSet, basename="districts")
+router.register("safezones", SafezoneViewSet, basename="safezones")
 
 urlpatterns = router.urls


### PR DESCRIPTION
## 🔍 What is the PR?

- SafezoneViewSet 추가
- /api/v1/safezones/gu (구 단위 요약) 엔드포인트 구현
- /api/v1/safezones/districts (안심존 동 목록) 엔드포인트 구현
- districts/urls.py 라우팅 수정 → SafezoneViewSet 등록
- 최신 스냅샷(as_of_date) 기준으로 안전 등급 판별 로직 적용
- final_grade 필드 추가(G1/G2 구분 제공)

## 📍 PR Point

- 안심존(구/동) API 신규 구현 완료
- 구 단위 중심 좌표는 구 전체 동 평균으로 계산
- 프론트에서 G1/G2 색상 구분 가능하도록 final_grade 필드 제공

## 📢 Notices

- safe_district_count 는 구 전체 동 개수로 반환됨
- final_grade: "G1" 또는 "G2" 만 제공 (수동 지정도 "G2")
- 기존 DistrictViewSet API에는 영향 없음

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
